### PR TITLE
Allow setting payment gateway url

### DIFF
--- a/src/VictoriaBank/Completion/CompletionRequest.php
+++ b/src/VictoriaBank/Completion/CompletionRequest.php
@@ -112,7 +112,12 @@ class CompletionRequest extends Request
                 'method' => 'POST',
                 'content' => http_build_query($this->_requestFields),
             ],
+            'ssl' => [
+                "verify_peer" => $this->_sslVerify,
+                "verify_peer_name" => $this->_sslVerify,
+            ]
         ];
+
         $context = stream_context_create($options);
         $result  = file_get_contents($this->_gatewayUrl, false, $context);
 

--- a/src/VictoriaBank/Request.php
+++ b/src/VictoriaBank/Request.php
@@ -35,7 +35,7 @@ abstract class Request implements RequestInterface
      * @var string
      */
     static public $privateKeyPath;
-    
+
     /**
      * Private key passphrase
      * @var string
@@ -50,7 +50,7 @@ abstract class Request implements RequestInterface
     /**
      * @var string
      */
-    protected $_gatewayUrl = 'https://egateway.victoriabank.md/cgi-bin/cgi_link';
+    protected $_gatewayUrl;
 
     /**
      * @var array
@@ -60,12 +60,13 @@ abstract class Request implements RequestInterface
     /**
      * Construct
      *
-     * @param array $requestParams
-     * @param bool  $debugMode
+     * @param array  $requestParams
+     * @param string $gatewayUrl
+     * @param bool   $debugMode
      *
      * @throws Exception
      */
-    public function __construct(array $requestParams, $debugMode = false)
+    public function __construct(array $requestParams, $gatewayUrl, $debugMode = false)
     {
         #Push the request field values
         foreach ($requestParams as $name => $value) {
@@ -74,8 +75,12 @@ abstract class Request implements RequestInterface
             }
             $this->_requestFields[$name] = $value;
         }
+
+        #Set gateway URL
+        $this->_gatewayUrl = $gatewayUrl;
         #Set debug mode
         $this->_debugMode = $debugMode;
+
         #Make sure to set these static params prior to calling the request
         if (is_null(self::$signatureFirst)) {
             throw new Exception('Could not instantiate the bank request - missing parameter signatureFirst');
@@ -115,6 +120,18 @@ abstract class Request implements RequestInterface
     public function setDebugMode($debugMode)
     {
         $this->_debugMode = (boolean)$debugMode;
+
+        return $this;
+    }
+
+    /**
+     * @param string $gatewayUrl
+     *
+     * @return $this
+     */
+    public function setGatewayUrl($gatewayUrl)
+    {
+        $this->_gatewayUrl = $gatewayUrl;
 
         return $this;
     }

--- a/src/VictoriaBank/Request.php
+++ b/src/VictoriaBank/Request.php
@@ -53,6 +53,11 @@ abstract class Request implements RequestInterface
     protected $_debugMode = false;
 
     /**
+     * @var bool
+     */
+    protected $_sslVerify = true;
+
+    /**
      * @var string
      */
     protected $_gatewayUrl;
@@ -68,10 +73,11 @@ abstract class Request implements RequestInterface
      * @param array  $requestParams
      * @param string $gatewayUrl
      * @param bool   $debugMode
+     * @param bool   $sslVerify
      *
      * @throws Exception
      */
-    public function __construct(array $requestParams, $gatewayUrl, $debugMode = false)
+    public function __construct(array $requestParams, $gatewayUrl, $debugMode = false, $sslVerify = true)
     {
         #Push the request field values
         foreach ($requestParams as $name => $value) {
@@ -85,6 +91,8 @@ abstract class Request implements RequestInterface
         $this->_gatewayUrl = $gatewayUrl;
         #Set debug mode
         $this->_debugMode = $debugMode;
+        #Set SSL verify mode
+        $this->_sslVerify = $sslVerify;
 
         #Make sure to set these static params prior to calling the request
         if (is_null(self::$signatureFirst)) {
@@ -125,6 +133,18 @@ abstract class Request implements RequestInterface
     public function setDebugMode($debugMode)
     {
         $this->_debugMode = (boolean)$debugMode;
+
+        return $this;
+    }
+
+    /**
+     * @param boolean $sslVerify
+     *
+     * @return $this
+     */
+    public function setSslVerify($sslVerify)
+    {
+        $this->_sslVerify = (boolean)$sslVerify;
 
         return $this;
     }

--- a/src/VictoriaBank/RequestInterface.php
+++ b/src/VictoriaBank/RequestInterface.php
@@ -10,7 +10,7 @@ interface RequestInterface
      * @param array $requestParams
      * @param bool  $debugMode
      */
-    public function __construct(array $requestParams, $debugMode = false);
+    public function __construct(array $requestParams, $gatewayUrl, $debugMode = false);
 
     /**
      * @param bool $debugMode
@@ -18,6 +18,13 @@ interface RequestInterface
      * @return $this
      */
     public function setDebugMode($debugMode);
+
+    /**
+     * @param string $gatewayUrl
+     *
+     * @return $this
+     */
+    public function setGatewayUrl($gatewayUrl);
 
     /**
      * Performs the actual request

--- a/src/VictoriaBank/Reversal/ReversalRequest.php
+++ b/src/VictoriaBank/Reversal/ReversalRequest.php
@@ -112,7 +112,12 @@ class ReversalRequest extends Request
                 'method' => 'POST',
                 'content' => http_build_query($this->_requestFields),
             ],
+            'ssl' => [
+                "verify_peer" => $this->_sslVerify,
+                "verify_peer_name" => $this->_sslVerify,
+            ]
         ];
+
         $context = stream_context_create($options);
         $result  = file_get_contents($this->_gatewayUrl, false, $context);
 

--- a/src/VictoriaBankGateway.php
+++ b/src/VictoriaBankGateway.php
@@ -24,6 +24,11 @@ class VictoriaBankGateway
     private $debug = false;
 
     /**
+     * @var bool
+     */
+    private $sslVerify = true;
+
+    /**
      * @var string
      */
     private $gatewayUrl = 'https://egateway.victoriabank.md/cgi-bin/cgi_link';
@@ -180,6 +185,20 @@ class VictoriaBankGateway
     public function setDebug($debug)
     {
         $this->debug = (boolean)$debug;
+
+        return $this;
+    }
+
+    /**
+     * SSL verify mode setter
+     *
+     * @param boolean $sslVerify
+     *
+     * @return $this
+     */
+    public function setSslVerify($sslVerify)
+    {
+        $this->sslVerify = (boolean)$sslVerify;
 
         return $this;
     }
@@ -418,7 +437,7 @@ class VictoriaBankGateway
                     VictoriaBank\Authorization\AuthorizationRequest::MERCH_NAME    => $this->merchantName,
                     VictoriaBank\Authorization\AuthorizationRequest::MERCH_URL     => $this->merchantUrl,
                     VictoriaBank\Authorization\AuthorizationRequest::MERCH_ADDRESS => $this->merchantAddress,
-                ], $this->gatewayUrl, $this->debug
+                ], $this->gatewayUrl, $this->debug, $this->sslVerify
             );
             $request->request();
         } catch (VictoriaBank\Exception $e) {
@@ -455,7 +474,7 @@ class VictoriaBankGateway
                     VictoriaBank\Completion\CompletionRequest::NONCE     => $this->generateNonce(),
                     VictoriaBank\Completion\CompletionRequest::RRN       => $rrn,
                     VictoriaBank\Completion\CompletionRequest::INT_REF   => $intRef,
-                ], $this->gatewayUrl, $this->debug
+                ], $this->gatewayUrl, $this->debug, $this->sslVerify
             );
 
             return $request->request();
@@ -493,7 +512,7 @@ class VictoriaBankGateway
                     VictoriaBank\Reversal\ReversalRequest::NONCE     => $this->generateNonce(),
                     VictoriaBank\Reversal\ReversalRequest::RRN       => $rrn,
                     VictoriaBank\Reversal\ReversalRequest::INT_REF   => $intRef,
-                ], $this->gatewayUrl, $this->debug
+                ], $this->gatewayUrl, $this->debug, $this->sslVerify
             );
 
             return $request->request();

--- a/src/VictoriaBankGateway.php
+++ b/src/VictoriaBankGateway.php
@@ -19,6 +19,11 @@ class VictoriaBankGateway
     /**
      * @var string
      */
+    private $gatewayUrl = 'https://egateway.victoriabank.md/cgi-bin/cgi_link';
+
+    /**
+     * @var string
+     */
     private $merchant;
 
     /**
@@ -166,6 +171,20 @@ class VictoriaBankGateway
     public function setDebug($debug)
     {
         $this->debug = (boolean)$debug;
+
+        return $this;
+    }
+
+    /**
+     * Set Gateway URL
+     *
+     * @param string $gatewayUrl
+     *
+     * @return $this
+     */
+    public function setGatewayUrl($gatewayUrl)
+    {
+        $this->gatewayUrl = $gatewayUrl;
 
         return $this;
     }
@@ -378,7 +397,7 @@ class VictoriaBankGateway
                     VictoriaBank\Authorization\AuthorizationRequest::MERCH_NAME => $this->merchantName,
                     VictoriaBank\Authorization\AuthorizationRequest::MERCH_URL => $this->merchantUrl,
                     VictoriaBank\Authorization\AuthorizationRequest::MERCH_ADDRESS => $this->merchantAddress,
-                ], $this->debug
+                ], $this->gatewayUrl, $this->debug
             );
             $request->request();
         } catch (VictoriaBank\Exception $e) {
@@ -415,7 +434,7 @@ class VictoriaBankGateway
                     VictoriaBank\Completion\CompletionRequest::NONCE => $this->generateNonce(),
                     VictoriaBank\Completion\CompletionRequest::RRN => $rrn,
                     VictoriaBank\Completion\CompletionRequest::INT_REF => $intRef,
-                ], $this->debug
+                ], $this->gatewayUrl, $this->debug
             );
 
             return $request->request();
@@ -453,7 +472,7 @@ class VictoriaBankGateway
                     VictoriaBank\Reversal\ReversalRequest::NONCE => $this->generateNonce(),
                     VictoriaBank\Reversal\ReversalRequest::RRN => $rrn,
                     VictoriaBank\Reversal\ReversalRequest::INT_REF => $intRef,
-                ], $this->debug
+                ], $this->gatewayUrl, $this->debug
             );
 
             return $request->request();


### PR DESCRIPTION
New customers are required to complete functionality tests according to the documentation with a test payment gateway.

Current implementation has the gateway url hardcoded in the `Request` class. This pull request allows the caller to set a different gateway url to enable onboarding test scenarios.

```
$victoriaBankGateway = new VictoriaBankGateway();
$victoriaBankGateway->setGatewayUrl('https://ecomt.victoriabank.md/cgi-bin/cgi_link');
```